### PR TITLE
Font Bug and Forwarding Touches

### DIFF
--- a/HTMLLabel/HTMLLabel.m
+++ b/HTMLLabel/HTMLLabel.m
@@ -235,7 +235,7 @@ NSString *const HTMLTextAlignment = @"textAlignment";
     }
     else
     {
-        font = [font fontWithSize:pointSize];
+        font = [UIFont fontWithName:font.fontName size:pointSize];
     }
     return font;
 }

--- a/HTMLLabel/HTMLLabel.m
+++ b/HTMLLabel/HTMLLabel.m
@@ -728,7 +728,7 @@ NSString *const HTMLTextAlignment = @"textAlignment";
                  @"ndash":@"–", @"mdash":@"—", @"apos":@"’", @"lsquo":@"‘", @"ldquo":@"“", @"rsquo":@"’", @"rdquo":@"”",
                  @"cent":@"¢", @"pound":@"£", @"euro":@"€", @"yen":@"¥", @"ntilde":@"\u00F1", @"#39":@"'", @"eacute":@"é",
                  @"frac14":@"¼", @"frac12":@"½", @"frac34":@"¾", @"ouml":@"ö", @"uuml":@"ü", @"oslash":@"ø", @"iacute":@"í",
-                 @"oacute":@"ó"
+                 @"oacute":@"ó", @"uacute":@"ú"
                  } inString:html];
                 [self replacePattern:@"&(?!(gt|lt|amp|quot|(#[0-9]+)));" inString:html withPattern:@""];
                 [self replacePattern:@"&(?![a-z0-9]+;)" inString:html withPattern:@"&amp;"];

--- a/HTMLLabel/HTMLLabel.m
+++ b/HTMLLabel/HTMLLabel.m
@@ -726,7 +726,8 @@ NSString *const HTMLTextAlignment = @"textAlignment";
                 [self replaceEntities:@{
                  @"nbsp":@"\u00A0", @"bull":@"•", @"copy":@"©", @"reg":@"®", @"deg":@"°",
                  @"ndash":@"–", @"mdash":@"—", @"apos":@"’", @"lsquo":@"‘", @"ldquo":@"“", @"rsquo":@"’", @"rdquo":@"”",
-                 @"cent":@"¢", @"pound":@"£", @"euro":@"€", @"yen":@"¥", @"ntilde":@"\u00F1", @"#39":@"'"
+                 @"cent":@"¢", @"pound":@"£", @"euro":@"€", @"yen":@"¥", @"ntilde":@"\u00F1", @"#39":@"'", @"eacute":@"é",
+                 @"frac14":@"¼", @"frac12":@"½", @"frac34":@"¾"
                  } inString:html];
                 [self replacePattern:@"&(?!(gt|lt|amp|quot|(#[0-9]+)));" inString:html withPattern:@""];
                 [self replacePattern:@"&(?![a-z0-9]+;)" inString:html withPattern:@"&amp;"];

--- a/HTMLLabel/HTMLLabel.m
+++ b/HTMLLabel/HTMLLabel.m
@@ -1334,6 +1334,7 @@ NSString *const HTMLTextAlignment = @"textAlignment";
     UITouch *touch = [touches anyObject];
     [_layout tokenAtPosition:[touch locationInView:self]].attributes.active = YES;
     [self setNeedsDisplay];
+    [self.nextResponder touchesCancelled:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
@@ -1358,12 +1359,14 @@ NSString *const HTMLTextAlignment = @"textAlignment";
         }
         if (openURL) [[UIApplication sharedApplication] openURL:URL];
     }
+    [self.nextResponder touchesCancelled:touches withEvent:event];
 }
 
 - (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event
 {
     [[_layout valueForKeyPath:@"tokens.attributes"] makeObjectsPerformSelector:@selector(setActive:) withObject:0];
     [self setNeedsDisplay];
+    [self.nextResponder touchesCancelled:touches withEvent:event];
 }
 
 @end

--- a/HTMLLabel/HTMLLabel.m
+++ b/HTMLLabel/HTMLLabel.m
@@ -735,7 +735,7 @@ NSString *const HTMLTextAlignment = @"textAlignment";
                 [self replacePattern:@"<(?![/a-z])" inString:html withPattern:@"&lt;"];
                 
                 //sanitize tags
-                [self replacePattern:@"([-_a-z]+)=([^\"'][^ >]+)" inString:html withPattern:@"$1=\"$2\""];
+                [self replacePattern:@"([-_a-z]+)=([^\"'][^ >]+)" inString:html withPattern:@"$1=$2"];
                 [self replacePattern:@"<(area|base|br|col|command|embed|hr|img|input|link|meta|param|source)(\\s[^>]*)?>" inString:html withPattern:@"<$1/>"];
                 
                 //wrap in html tag

--- a/HTMLLabel/HTMLLabel.m
+++ b/HTMLLabel/HTMLLabel.m
@@ -727,7 +727,7 @@ NSString *const HTMLTextAlignment = @"textAlignment";
                  @"nbsp":@"\u00A0", @"bull":@"•", @"copy":@"©", @"reg":@"®", @"deg":@"°",
                  @"ndash":@"–", @"mdash":@"—", @"apos":@"’", @"lsquo":@"‘", @"ldquo":@"“", @"rsquo":@"’", @"rdquo":@"”",
                  @"cent":@"¢", @"pound":@"£", @"euro":@"€", @"yen":@"¥", @"ntilde":@"\u00F1", @"#39":@"'", @"eacute":@"é",
-                 @"frac14":@"¼", @"frac12":@"½", @"frac34":@"¾"
+                 @"frac14":@"¼", @"frac12":@"½", @"frac34":@"¾", @"ouml":@"ö", @"uuml":@"ü", @"oslash":@"ø", @"iacute":@"í"
                  } inString:html];
                 [self replacePattern:@"&(?!(gt|lt|amp|quot|(#[0-9]+)));" inString:html withPattern:@""];
                 [self replacePattern:@"&(?![a-z0-9]+;)" inString:html withPattern:@"&amp;"];

--- a/HTMLLabel/HTMLLabel.m
+++ b/HTMLLabel/HTMLLabel.m
@@ -1334,7 +1334,7 @@ NSString *const HTMLTextAlignment = @"textAlignment";
     UITouch *touch = [touches anyObject];
     [_layout tokenAtPosition:[touch locationInView:self]].attributes.active = YES;
     [self setNeedsDisplay];
-    [self.nextResponder touchesCancelled:touches withEvent:event];
+    [self.nextResponder touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
@@ -1359,7 +1359,7 @@ NSString *const HTMLTextAlignment = @"textAlignment";
         }
         if (openURL) [[UIApplication sharedApplication] openURL:URL];
     }
-    [self.nextResponder touchesCancelled:touches withEvent:event];
+    [self.nextResponder touchesEnded:touches withEvent:event];
 }
 
 - (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event

--- a/HTMLLabel/HTMLLabel.m
+++ b/HTMLLabel/HTMLLabel.m
@@ -727,7 +727,8 @@ NSString *const HTMLTextAlignment = @"textAlignment";
                  @"nbsp":@"\u00A0", @"bull":@"•", @"copy":@"©", @"reg":@"®", @"deg":@"°",
                  @"ndash":@"–", @"mdash":@"—", @"apos":@"’", @"lsquo":@"‘", @"ldquo":@"“", @"rsquo":@"’", @"rdquo":@"”",
                  @"cent":@"¢", @"pound":@"£", @"euro":@"€", @"yen":@"¥", @"ntilde":@"\u00F1", @"#39":@"'", @"eacute":@"é",
-                 @"frac14":@"¼", @"frac12":@"½", @"frac34":@"¾", @"ouml":@"ö", @"uuml":@"ü", @"oslash":@"ø", @"iacute":@"í"
+                 @"frac14":@"¼", @"frac12":@"½", @"frac34":@"¾", @"ouml":@"ö", @"uuml":@"ü", @"oslash":@"ø", @"iacute":@"í",
+                 @"oacute":@"ó"
                  } inString:html];
                 [self replacePattern:@"&(?!(gt|lt|amp|quot|(#[0-9]+)));" inString:html withPattern:@""];
                 [self replacePattern:@"&(?![a-z0-9]+;)" inString:html withPattern:@"&amp;"];


### PR DESCRIPTION
**Font Bug:**

My label using a custom font (Fort-Book) gets changed to Fort-Bold when using UIFont's -fontWithSize:

This is a bug in iOS 8 (sample project here: https://github.com/djibouti33/UIFontBug), and I have provided a workaround for it.

*\* Forwarding Touches **

I had a very specific use case where my HTMLLabel was inside a UITableViewCell, and selecting the label would prevent the tableView's didSelectRowAtIndexPath: method from firing. I'd be happy to share the details of why I needed the HTMLLabel delegate and the UITableView delegate to fire if you're hesitant to include this update.
