### PR TITLE
workaround for bug in iOS 8 where -fontWithSize returns different fon…

### DIFF
--- a/HTMLLabel/HTMLLabel.m
+++ b/HTMLLabel/HTMLLabel.m
@@ -235,7 +235,7 @@ NSString *const HTMLTextAlignment = @"textAlignment";
     }
     else
     {
-        font = [font fontWithSize:pointSize];
+        font = [UIFont fontWithName:font.fontName size:pointSize];
     }
     return font;
 }


### PR DESCRIPTION
…t object

My label using a custom font (Fort-Book) gets changed to Fort-Bold when using UIFont's -fontWithSize:

This is a bug in iOS 8 (sample project here: https://github.com/djibouti33/UIFontBug), and I have provided a workaround for it.
