### PR TITLE
removing quotes around capture group to prevent replacement method fr…

### DIFF
--- a/HTMLLabel/HTMLLabel.m
+++ b/HTMLLabel/HTMLLabel.m
@@ -734,7 +734,7 @@ NSString *const HTMLTextAlignment = @"textAlignment";
                 [self replacePattern:@"<(?![/a-z])" inString:html withPattern:@"&lt;"];
                 
                 //sanitize tags
-                [self replacePattern:@"([-_a-z]+)=([^\"'][^ >]+)" inString:html withPattern:@"$1=\"$2\""];
+                [self replacePattern:@"([-_a-z]+)=([^\"'][^ >]+)" inString:html withPattern:@"$1=$2"];
                 [self replacePattern:@"<(area|base|br|col|command|embed|hr|img|input|link|meta|param|source)(\\s[^>]*)?>" inString:html withPattern:@"<$1/>"];
                 
                 //wrap in html tag


### PR DESCRIPTION
om prematurely ending a string with a quote character.

More information in [Issue 19](https://github.com/nicklockwood/HTMLLabel/issues/19)
